### PR TITLE
Make path separator for search_path always a semicolon

### DIFF
--- a/src/main/groovy/net/foragerr/jmeter/gradle/plugins/TaskJMInit.groovy
+++ b/src/main/groovy/net/foragerr/jmeter/gradle/plugins/TaskJMInit.groovy
@@ -90,7 +90,7 @@ class TaskJMInit extends DefaultTask{
         StringBuilder cp = new StringBuilder()
         URL[] classPath = ((URLClassLoader)this.getClass().getClassLoader()).getURLs()
         String jmeterVersionPattern = project.jmeter.jmVersion.replaceAll("[.]", "[.]")
-        String pathSeparator = File.pathSeparator;
+        String pathSeparator = ';';
         for (URL dep : classPath) {
             if (dep.getPath().matches("^.*org[./]apache[./]jmeter[/]ApacheJMeter.*" +
                     jmeterVersionPattern + ".jar\$")) {


### PR DESCRIPTION
http://jmeter.apache.org/usermanual/get-started.html states that this is always ';', but System.pathSeparator can be ':' on Linux, MacOS, and other systems:

```
    search_paths    List of paths (separated by ;) that JMeter will search for JMeter plugin classes, for example additional samplers.
```
