### PR TITLE
-DXmsnull was being passed when not previously specified

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -173,7 +173,7 @@ dependencies {
         exclude group: 'xml-apis', module: 'xml-apis'
     }
 
-	testCompile "junit:junit:4.11"
+    testCompile 'org.spockframework:spock-core:1.0-groovy-2.3'
 }
 
 

--- a/src/main/groovy/net/foragerr/jmeter/gradle/plugins/worker/JMeterRunner.groovy
+++ b/src/main/groovy/net/foragerr/jmeter/gradle/plugins/worker/JMeterRunner.groovy
@@ -33,8 +33,8 @@ class JMeterRunner {
 
         List<String> argumentsList = new ArrayList<>()
         argumentsList.add(javaRuntime)
-        argumentsList.add("-Xms${specs.minHeapSize}".toString())
-        argumentsList.add("-Xmx${specs.maxHeapSize}".toString())
+        if (specs.minHeapSize) { argumentsList.add("-Xms${specs.minHeapSize}".toString()) }
+        if (specs.maxHeapSize) { argumentsList.add("-Xmx${specs.maxHeapSize}".toString()) }
         argumentsList.addAll(specs.getUserSystemProperties())
         specs.getSystemProperties().each {k,v ->
             argumentsList.add("-D$k=$v".toString())

--- a/src/test/groovy/net/foragerr/jmeter/gradle/plugins/worker/JMeterRunnerSpec.groovy
+++ b/src/test/groovy/net/foragerr/jmeter/gradle/plugins/worker/JMeterRunnerSpec.groovy
@@ -1,0 +1,37 @@
+package net.foragerr.jmeter.gradle.plugins.worker
+
+import net.foragerr.jmeter.gradle.plugins.JMSpecs
+
+import spock.lang.Specification
+
+class JMeterRunnerSpec extends Specification {
+
+
+    JMeterRunner runner
+
+    void setup() {
+        runner = new JMeterRunner()
+    }
+
+    void 'null JMSpecs do not propogate'() {
+        given:
+        JMSpecs specs = Mock()
+        final String workDir = new File(new File('temp').absolutePath).parent
+        final String launchClass = 'FooClass'
+
+        when:
+        String[] args = runner.createArgumentList(specs, workDir, launchClass)
+
+        then:
+        args[0] == 'java'
+        args[1] == '-Xmx64'
+        args[2] == '-cp'
+        args[4] == 'FooClass'
+        1 * specs.getMinHeapSize() >> null
+        2 * specs.getMaxHeapSize() >> 64
+        1 * specs.getUserSystemProperties() >> []
+        1 * specs.getSystemProperties() >> [:]
+        1 * specs.getJmeterProperties() >> []
+        0 * _
+    }
+}


### PR DESCRIPTION
My `Xms` was not specified, so the plugin was injecting the string `null`.  This should fix it for others if they run into this issue.
