### PR TITLE
Add parameter to pass error threshold

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ apply plugin: 'maven-publish'
 group = 'net.foragerr.jmeter'
 archivesBaseName = 'jmeter-gradle-plugin'
 
-ext.thisPluginVersion="1.1.1"
+ext.thisPluginVersion="1.1.2"
 ext.jmVersion = "5.0"
 ext.jmPluginVersion = "1.4.0"
 version = "$thisPluginVersion-$jmVersion-SNAPSHOT"

--- a/src/main/groovy/net/foragerr/jmeter/gradle/plugins/JMPluginExtension.groovy
+++ b/src/main/groovy/net/foragerr/jmeter/gradle/plugins/JMPluginExtension.groovy
@@ -27,6 +27,7 @@ class JMPluginExtension {
     Boolean csvLogFile = null
     Boolean showSummarizer = null
 	Boolean failBuildOnError = null
+    Double errorThreshold = null
 
     // Report Options //
     Boolean enableReports = true

--- a/src/main/groovy/net/foragerr/jmeter/gradle/plugins/TaskJMInit.groovy
+++ b/src/main/groovy/net/foragerr/jmeter/gradle/plugins/TaskJMInit.groovy
@@ -42,6 +42,9 @@ class TaskJMInit extends DefaultTask {
         project.jmeter.csvLogFile = project.jmeter.csvLogFile == null ? true : project.jmeter.csvLogFile
         project.jmeter.showSummarizer = project.jmeter.showSummarizer == null ? true : project.jmeter.showSummarizer
 		project.jmeter.failBuildOnError = project.jmeter.failBuildOnError == null ? true : project.jmeter.failBuildOnError
+		project.jmeter.errorThreshold = project.jmeter.errorThreshold == null ? 0.0 : project.jmeter.errorThreshold
+        assert project.jmeter.errorThreshold >= 0.0 && project.jmeter.errorThreshold <= 100.0
+
         
         LoadPluginProperties()
         project.jmeter.jmVersion = this.jmeterVersion

--- a/src/main/groovy/net/foragerr/jmeter/gradle/plugins/TaskJMRun.groovy
+++ b/src/main/groovy/net/foragerr/jmeter/gradle/plugins/TaskJMRun.groovy
@@ -30,7 +30,12 @@ public class TaskJMRun extends DefaultTask {
     }
 
     private void checkForErrors(List<File> results) {
-        ErrorScanner scanner = new ErrorScanner(project.jmeter.ignoreErrors, project.jmeter.ignoreFailures, project.jmeter.failBuildOnError);
+        ErrorScanner scanner = new ErrorScanner(
+                project.jmeter.ignoreErrors,
+                project.jmeter.ignoreFailures,
+                project.jmeter.failBuildOnError,
+                project.jmeter.csvLogFile,
+                project.jmeter.errorThreshold)
         try {
             for (File file : results) {
                 if (scanner.scanForProblems(file)) {

--- a/src/main/groovy/net/foragerr/jmeter/gradle/plugins/utils/ErrorScanner.groovy
+++ b/src/main/groovy/net/foragerr/jmeter/gradle/plugins/utils/ErrorScanner.groovy
@@ -1,29 +1,89 @@
 package net.foragerr.jmeter.gradle.plugins.utils
 
 import org.gradle.api.GradleException
-import java.io.BufferedReader
-import java.io.File
-
+import org.gradle.api.logging.Logger
+import org.gradle.api.logging.Logging
 
 class ErrorScanner {
+    private static final String CSV_PAT_HEADER = ",success,"
     private static final String PAT_ERROR = "<error>true</error>"
-    private static final String PAT_FAILURE_REQUEST = "s=\"false\""
     private static final String PAT_FAILURE = "<failure>true</failure>"
     private static final String PAT_FALSE = ",false,"
-    
+    private static final String LINE_SEPARATOR = "-------------------------------------------------------";
+
+    private final Logger log = Logging.getLogger(getClass())
     def ignoreErrors
     def ignoreFailures
     def failBuildOnError
+    def csvLogFile
+    def errorThreshold
 
-    ErrorScanner(def ignoreErrors, def ignoreFailures, def failBuildOnError) {
+    ErrorScanner(def ignoreErrors, def ignoreFailures, def failBuildOnError, def csvLogFile, def errorThreshold) {
         this.ignoreErrors = ignoreErrors
         this.ignoreFailures = ignoreFailures
         this.failBuildOnError = failBuildOnError
+        this.csvLogFile = csvLogFile
+        this.errorThreshold = errorThreshold
     }
 
-    public boolean scanForProblems(File file) throws IOException {
-        def result = false;
-        file.eachLine {line ->
+    public boolean scanForProblems(File file) {
+        if (this.errorThreshold == 0.0) {
+            return checkForFirstError(file)
+        } else {
+            return checkThreshold(file)
+        }
+    }
+
+    private boolean checkThreshold(File file) {
+        int totalTestCount = 0
+        int countTestFailures = 0
+        if (this.csvLogFile == true) {
+            file.eachLine { line ->
+                if (!line.contains(CSV_PAT_HEADER)) { // Ignore 1st line in CSV
+                    totalTestCount++
+                }
+                if (line.contains(PAT_FALSE)) {
+                    countTestFailures++
+                }
+            }
+        } else {
+            def testResults = (new XmlParser()).parse(file).value()
+            testResults.each {
+                httpSample ->
+                    boolean isThereAFailure = false
+                    httpSample.assertionResult.each {
+                        assertionResult ->
+                            if (assertionResult.error[0].text() == 'true' ||
+                                    assertionResult.failure[0].text() == 'true') {
+                                isThereAFailure = true
+                            }
+                    }
+                    totalTestCount++
+                    if (isThereAFailure) {
+                        countTestFailures++
+                    }
+            }
+        }
+        log.info(LINE_SEPARATOR)
+        log.info("P E R F O R M A N C E    T E S T    R E S U L T S")
+        log.info(LINE_SEPARATOR)
+        log.info("Total requests:\t\t\t{}", totalTestCount)
+        log.info("Failed requests:\t\t{}", countTestFailures)
+        double failurePercentage = (countTestFailures * 100.0) / totalTestCount
+        log.info("Failures:\t\t\t{}% ({}% accepted)", failurePercentage, errorThreshold)
+        log.info(LINE_SEPARATOR)
+        if (failurePercentage <= this.errorThreshold) {
+            return false
+        }
+        throw new GradleException(
+                String.format("Failing build because error percentage %s is above accepted threshold %s",
+                        failurePercentage, errorThreshold))
+    }
+
+
+    private boolean checkForFirstError(File file) {
+        def result = false
+        file.eachLine { line ->
             def lineResult = lineContainsForErrors(line)
             if (!result) {
                 result = lineResult


### PR DESCRIPTION
Add parameter `errorThreshold` to pass error threshold to test run.

By default ErrorScanner is set to follow old way of checking error/failures.